### PR TITLE
Fix hitting DB when cache value is empty

### DIFF
--- a/keyvaluestore/managers.py
+++ b/keyvaluestore/managers.py
@@ -9,7 +9,7 @@ class KeyValueStoreManager(models.Manager):
         cached_key = get_cache_key(key)
         cached = cache.get(cached_key)
 
-        if not cached:
+        if cached is None:
             try:
                 obj = self.get(key=key)
                 cache.set(cached_key, obj.value)


### PR DESCRIPTION
Cache values could be empty strings (correctly) and this would refetch the value from the DB.